### PR TITLE
Mark main as a release branch for tagging purposes

### DIFF
--- a/.github/workflows/cut-tag-main.yaml
+++ b/.github/workflows/cut-tag-main.yaml
@@ -36,4 +36,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CUSTOM_TAG: ${{ steps.current-version.outputs.version }}
+        RELEASE_BRANCHES: main
+
       if: steps.current-version.outputs.version != steps.latest-release.outputs.release


### PR DESCRIPTION
## Why

The action we're using to automatically create new tags assumes that your default branch is 'master' and this repo's default branch is 'main'.

## Library Checklist

[X] I have described my changes in detail in my commit message, breaking things down as described in the [README](README.md)