### PR TITLE
Trigger publish action on tag creation

### DIFF
--- a/.github/workflows/publish-tag.yaml
+++ b/.github/workflows/publish-tag.yaml
@@ -1,8 +1,8 @@
 name: Publish New Tag To Github and PyPI
 
 on:
-  push:
-    tags: '*'
+  create:
+    types: [tag]
 
 jobs:
   publish-release:
@@ -24,7 +24,7 @@ jobs:
 
     - name: Blow up if version does not match tag
       run: exit 1
-      if: github.event.ref != format('refs/tags/{0}', steps.current-version.outputs.version)
+      if: github.event.ref != steps.current-version.outputs.version
 
     - name: Cache dependencies
       uses: actions/cache@v2


### PR DESCRIPTION
## Why

The Github Actions user doesn't trigger certain types of event in order to prevent infinite loops. This includes "push" events, which means that we can't bind the publishing workflow to the "push tag" event if a github action is responsible for pushing the tag. Instead, we bind to the tag creation event.

## Library Checklist

[ ] I have described my changes in detail in my commit message, breaking things down as described in the [README](README.md)