### PR TITLE
Generate and include type stubs in published package

### DIFF
--- a/.github/workflows/publish-tag.yaml
+++ b/.github/workflows/publish-tag.yaml
@@ -42,6 +42,9 @@ jobs:
       id: dependencies
       run: poetry install
 
+    - name: Generate stubs
+      run: poetry run stubgen -p dagster_utils -o stubs
+
     - name: Build library artifacts
       run: poetry build
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ poetry.lock
 .mypy_cache
 .pytest_cache
 dist
+stubs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "broad_dagster_utils"
 license = "BSD-3-Clause"
 readme = "README.md"
 repository = "https://github.com/broadinstitute/dagster-utils"
-version = "0.1.2"
+version = "0.2.0"
 
 description = "Common utilities and objects for building Dagster pipelines"
 authors = ["Steve Pletcher <spletche@broadinstitute.org>"]
@@ -12,11 +12,13 @@ packages = [
 	{ include = "dagster_utils" }
 ]
 
+include = ["stubs/dagster_utils/**/*.pyi"]
+
 [tool.poetry.dependencies]
 # [2021-05-03]
 # We're locked out of using python 3.10 because the BigQuery library doesn't support it.
 # I'd expect this to change relatively soon after release, so check back occasionally.
-python = ">=3.9,<3.10"
+python = "~3.9"
 dagster = "^0.11.6"
 google-cloud-storage = "^1.38.0"
 PyYAML = "^5.4.1"


### PR DESCRIPTION
## Why

Type hints aren't available from a compiled package by default, so we need to explicitly build and bundle our stubs or Mypy can't read them.

## Library Checklist

[X] I have described my changes in detail in my commit message, breaking things down as described in the [README](README.md)