### PR TITLE
Changes to support dspdc-1699

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,4 +7,4 @@
 
 ## Library Checklist
 
-[ ] I have described my changes in detail in my commit message, breaking things down as described in the [README](README.md)
+- [ ] I have described my changes in detail in my commit message, breaking things down as described in the [README](README.md)

--- a/dagster_utils/contrib/google.py
+++ b/dagster_utils/contrib/google.py
@@ -20,3 +20,7 @@ def default_google_access_token() -> str:
 
 def authorized_session() -> AuthorizedSession:
     return AuthorizedSession(default_google_access_token())
+
+
+def gs_path_from_bucket_prefix(bucket: str, prefix: str) -> str:
+    return f"gs://{bucket}/{prefix}"

--- a/dagster_utils/resources/bigquery.py
+++ b/dagster_utils/resources/bigquery.py
@@ -4,14 +4,10 @@ from dagster_utils.contrib.google import get_credentials
 
 from unittest.mock import Mock
 
+
 @resource
 def bigquery_client(init_context: InitResourceContext) -> Client:
     return Client(credentials=get_credentials())
-
-
-class NoopBigQueryClient:
-    def create_dataset(self, dataset: Dataset) -> None:
-        pass
 
 
 @resource

--- a/dagster_utils/resources/bigquery.py
+++ b/dagster_utils/resources/bigquery.py
@@ -2,6 +2,7 @@ from google.cloud.bigquery import Dataset, Client
 from dagster import resource, InitResourceContext
 from dagster_utils.contrib.google import get_credentials
 
+from unittest.mock import Mock
 
 @resource
 def bigquery_client(init_context: InitResourceContext) -> Client:
@@ -15,4 +16,4 @@ class NoopBigQueryClient:
 
 @resource
 def noop_bigquery_client(init_context: InitResourceContext) -> Client:
-    return NoopBigQueryClient()
+    return Mock(spec=Client)

--- a/dagster_utils/resources/google_storage.py
+++ b/dagster_utils/resources/google_storage.py
@@ -18,6 +18,7 @@ def google_storage_client(_: InitResourceContext) -> storage.Client:
 @dataclass
 class MockBlob:
     name: str
+
     def delete(self) -> None:
         pass
 

--- a/dagster_utils/resources/google_storage.py
+++ b/dagster_utils/resources/google_storage.py
@@ -1,4 +1,5 @@
 from typing import Iterator
+from dataclasses import dataclass
 
 from dagster import resource
 from dagster.core.execution.context.init import InitResourceContext
@@ -14,15 +15,17 @@ def google_storage_client(_: InitResourceContext) -> storage.Client:
     return storage.Client(project=project, credentials=credentials)
 
 
+@dataclass
 class MockBlob:
+    name: str
     def delete(self) -> None:
         pass
 
 
 class MockStorageClient:
     def list_blobs(self, bucket_name: str, prefix: str) -> Iterator[MockBlob]:
-        for _ in range(0, 10):
-            yield MockBlob()
+        for i in range(0, 10):
+            yield MockBlob(f"fake_blob_{i}")
 
 
 @resource

--- a/dagster_utils/resources/jade_data_repo.py
+++ b/dagster_utils/resources/jade_data_repo.py
@@ -28,13 +28,22 @@ class NoopDataRepoClient:
     @dataclass
     class FakeJobResponse:
         completed: bool
+        id: str
+        job_status: str
 
     def enumerate_datasets(self) -> NoopResult:
         return NoopDataRepoClient.NoopResult(5)
 
     def retrieve_job(self, job_id: str) -> FakeJobResponse:
-        return NoopDataRepoClient.FakeJobResponse(True)
+        return NoopDataRepoClient.FakeJobResponse(True, "abcdef", "succeeded")
 
+    def bulk_file_load(self, dataset_id: str, bulk_file_load: dict[str, str]) -> FakeJobResponse:
+        return NoopDataRepoClient.FakeJobResponse(True, "abcdef", "succeeded")
+
+    def retrieve_job_result(self, job_id: str) -> dict[str, int]:
+        return {
+            "failedFiles": 0
+        }
 
 @resource
 def noop_data_repo_client(init_context: InitResourceContext) -> NoopDataRepoClient:

--- a/dagster_utils/resources/jade_data_repo.py
+++ b/dagster_utils/resources/jade_data_repo.py
@@ -45,6 +45,7 @@ class NoopDataRepoClient:
             "failedFiles": 0
         }
 
+
 @resource
 def noop_data_repo_client(init_context: InitResourceContext) -> NoopDataRepoClient:
     return NoopDataRepoClient()


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1699)
Our resource mocks need some changes to support DSPDC-1699 (data file loading).

## This PR
* Adds a helper to our google support module that constructs a valid GS path from a separate bucket and prefix
* Adds new methods to the datarepo client
* Adjusts the noop bigquery client to be a Mock spec'ed by `google.cloud.bigquery.Client`

## Library Checklist

- [x] I have described my changes in detail in my commit message, breaking things down as described in the [README](README.md)
