### PR TITLE
Alter GCP resources to use authorized sessions, auto-refresh credentials used in data repo client

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A collection of common utilities used by the Monster team to develop Dagster pip
 
 ## How to use this library
 
-This library is hosted on PyPI](https://pypi.org/) and will work with most Python package managers out of the box. You can reference this package as `broad_dagster_utils`, e.g. for Poetry:
+This library is hosted on [PyPI](https://pypi.org/) and will work with most Python package managers out of the box. You can reference this package as `broad_dagster_utils`, e.g. for Poetry:
 
 ```
 # pyproject.toml

--- a/dagster_utils/contrib/google.py
+++ b/dagster_utils/contrib/google.py
@@ -8,7 +8,7 @@ DEFAULT_SCOPES = ['openid', 'email', 'profile', 'https://www.googleapis.com/auth
 
 
 def google_default() -> tuple[Credentials, str]:
-    return google.auth.default(scopes=DEFAULT_SCOPES)
+    return google.auth.default(scopes=DEFAULT_SCOPES)  # type: ignore # (unannotated library)
 
 
 def get_credentials() -> Credentials:

--- a/dagster_utils/contrib/google.py
+++ b/dagster_utils/contrib/google.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import google.auth
 from google.auth.transport.requests import AuthorizedSession, Request
 from google.oauth2.credentials import Credentials
@@ -5,18 +7,27 @@ from google.oauth2.credentials import Credentials
 DEFAULT_SCOPES = ['openid', 'email', 'profile', 'https://www.googleapis.com/auth/cloud-platform']
 
 
+def google_default() -> tuple[Credentials, str]:
+    return google.auth.default(scopes=DEFAULT_SCOPES)
+
+
 def get_credentials() -> Credentials:
-    creds, _ = google.auth.default(scopes=DEFAULT_SCOPES)
+    creds, _ = google_default()
     return creds
 
 
-def default_google_access_token() -> str:
-    # get token for google-based auth use, assumes application default credentials work for specified environment
-    credentials = get_credentials()
+def default_google_access_token(credentials: Optional[Credentials] = None) -> str:
+    """
+    Get token for Google-based auth use.
+    Assumes application default credentials work for specified environment.
+    Note that this token will only be valid for 60 minutes. For uses that may need to
+    make requests for longer than this, use an AuthorizedSession (which auto-refreshes the token).
+    """
+    credentials = credentials or get_credentials()
     credentials.refresh(Request())
 
     return credentials.token  # type: ignore # (unannotated library)
 
 
 def authorized_session() -> AuthorizedSession:
-    return AuthorizedSession(default_google_access_token())
+    return AuthorizedSession(get_credentials())

--- a/dagster_utils/resources/bigquery.py
+++ b/dagster_utils/resources/bigquery.py
@@ -1,11 +1,12 @@
 from google.cloud.bigquery import Dataset, Client
 from dagster import resource, InitResourceContext
-from dagster_utils.contrib.google import get_credentials
+
+from dagster_utils.contrib.google import authorized_session
 
 
 @resource
 def bigquery_client(init_context: InitResourceContext) -> Client:
-    return Client(credentials=get_credentials())
+    return Client(_http=authorized_session())
 
 
 class NoopBigQueryClient:

--- a/dagster_utils/resources/google_storage.py
+++ b/dagster_utils/resources/google_storage.py
@@ -3,15 +3,16 @@ from typing import Iterator
 from dagster import resource
 from dagster.core.execution.context.init import InitResourceContext
 
-import google.auth
 from google.cloud import storage
+
+from dagster_utils.contrib.google import authorized_session, google_default
 
 
 @resource
 def google_storage_client(_: InitResourceContext) -> storage.Client:
-    credentials, project = google.auth.default()
+    _, project = google_default()
 
-    return storage.Client(project=project, credentials=credentials)
+    return storage.Client(project=project, _http=authorized_session())
 
 
 class MockBlob:

--- a/dagster_utils/resources/jade_data_repo.py
+++ b/dagster_utils/resources/jade_data_repo.py
@@ -5,15 +5,29 @@ from dagster.core.execution.context.init import InitResourceContext
 
 from data_repo_client import ApiClient, Configuration, RepositoryApi
 
-from dagster_utils.contrib.google import default_google_access_token
+from dagster_utils.contrib.google import default_google_access_token, get_credentials
 
 
 @resource({
     "api_url": Field(StringSource)
 })
 def jade_data_repo_client(init_context: InitResourceContext) -> RepositoryApi:
-    config = Configuration(host=init_context.resource_config["api_url"])
-    config.access_token = default_google_access_token()
+    config = Configuration(
+        host=init_context.resource_config["api_url"],
+        api_key={'Authorization': None},  # will be overwritten when we generate a request, see below
+        api_key_prefix={'Authorization': 'Bearer'},
+    )
+
+    # not an attribute of the Configuration class - we use this in the below method.
+    config._gcloud_credentials = get_credentials()
+
+    # The data repo client calls this function every time it tries to build the
+    # authorization headers for a new request, so we'll have a new token generated for each request.
+    def refresh_configured_api_key(conf: Configuration) -> None:
+        conf.api_key['Authorization'] = default_google_access_token(conf._datarepo_gcloud_credentials)
+
+    config.refresh_api_key_hook = refresh_configured_api_key
+
     client = ApiClient(configuration=config)
     client.client_side_validation = False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "broad_dagster_utils"
 license = "BSD-3-Clause"
 readme = "README.md"
 repository = "https://github.com/broadinstitute/dagster-utils"
-version = "0.2.2"
+version = "0.3.0"
 
 description = "Common utilities and objects for building Dagster pipelines"
 authors = ["Steve Pletcher <spletche@broadinstitute.org>"]


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1752)

## This PR

New features:
* contrib.google.default_google_access_token now optionally accepts a Credentials object, which it will use to generate a token
* All GCP resources (and resources that authenticate using GCP) now automatically refresh tokens each time they make a request.

Bugfixes:
* contrib.google.authorized_session now correctly passes a Credentials object to the constructor rather than a raw access token

## Library Checklist

[X] I have described my changes in detail in my commit message, breaking things down as described in the [README](README.md)