### PR TITLE
Fix mismatched variable name in data repo API config

### DIFF
--- a/dagster_utils/resources/jade_data_repo.py
+++ b/dagster_utils/resources/jade_data_repo.py
@@ -19,13 +19,13 @@ def jade_data_repo_client(init_context: InitResourceContext) -> RepositoryApi:
     )
 
     # not an attribute of the Configuration class - we use this in the below method.
-    config._gcloud_credentials = get_credentials()
+    config._datarepo_gcloud_credentials = get_credentials()
 
-    # The data repo client calls this function every time it tries to build the
-    # authorization headers for a new request, so we'll have a new token generated for each request.
     def refresh_configured_api_key(conf: Configuration) -> None:
         conf.api_key['Authorization'] = default_google_access_token(conf._datarepo_gcloud_credentials)
 
+    # The data repo client calls this function every time it tries to build the
+    # authorization headers for a new request, so we'll have a new token generated for each request.
     config.refresh_api_key_hook = refresh_configured_api_key
 
     client = ApiClient(configuration=config)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "broad_dagster_utils"
 license = "BSD-3-Clause"
 readme = "README.md"
 repository = "https://github.com/broadinstitute/dagster-utils"
-version = "0.3.0"
+version = "0.3.1"
 
 description = "Common utilities and objects for building Dagster pipelines"
 authors = ["Steve Pletcher <spletche@broadinstitute.org>"]


### PR DESCRIPTION
## Why

* Introduced a bug by not correctly matching variable names in data repo config

## This PR

* Makes 'em match


## Library Checklist

- [ ] I have described my changes in detail in my commit message, breaking things down as described in the [README](README.md)