### PR TITLE
Update slack client to allow blocks and update noopjadeclient

### DIFF
--- a/dagster_utils/resources/data_repo/jade_data_repo.py
+++ b/dagster_utils/resources/data_repo/jade_data_repo.py
@@ -34,6 +34,9 @@ class NoopDataRepoClient:
         id: str
         job_status: str
 
+    def create_snapshot(self, snapshot: dict[str, str]) -> FakeJobResponse:
+        return NoopDataRepoClient.FakeJobResponse(True, "abcdef", "succeeded")
+
     def enumerate_datasets(self) -> NoopResult:
         return NoopDataRepoClient.NoopResult(5)
 
@@ -43,8 +46,10 @@ class NoopDataRepoClient:
     def bulk_file_load(self, dataset_id: str, bulk_file_load: dict[str, str]) -> FakeJobResponse:
         return NoopDataRepoClient.FakeJobResponse(True, "abcdef", "succeeded")
 
-    def retrieve_job_result(self, job_id: str) -> dict[str, int]:
+    def retrieve_job_result(self, job_id: str) -> dict[str, object]:
         return {
+            "id": "fake_object_id",
+            "name": "fake_object_name",
             "failedFiles": 0
         }
 

--- a/dagster_utils/resources/slack.py
+++ b/dagster_utils/resources/slack.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Callable, Literal
+from typing import Callable, Literal, Optional
 
 import slack
 from dagster import DagsterLogManager, failure_hook, HookContext, HookDefinition,\
@@ -15,8 +15,8 @@ SlackMessageGenerator = Callable[[HookContext], str]
 class ConsoleSlackClient:
     logger: DagsterLogManager
 
-    def send_message(self, text: str) -> None:
-        self.logger.info(f"[SLACK] {text}")
+    def send_message(self, text: Optional[str] = None, blocks: Optional[list[dict[str, object]]] = None) -> None:
+        self.logger.info(f"[SLACK] {text} {blocks}")
 
 
 @resource
@@ -29,8 +29,8 @@ class LiveSlackClient:
     client: slack.WebClient
     channel: str
 
-    def send_message(self, text: str) -> None:
-        self.client.chat_postMessage(channel=self.channel, text=text)
+    def send_message(self, text: Optional[str] = None, blocks: Optional[list[dict[str, object]]] = None) -> None:
+        self.client.chat_postMessage(channel=self.channel, text=text, blocks=blocks)
 
 
 @resource({

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,10 +3,10 @@ name = "broad_dagster_utils"
 license = "BSD-3-Clause"
 readme = "README.md"
 repository = "https://github.com/broadinstitute/dagster-utils"
-version = "0.4.1"
+version = "0.4.2"
 
 description = "Common utilities and objects for building Dagster pipelines"
-authors = ["Steve Pletcher <spletche@broadinstitute.org>"]
+authors = ["Monster Dev <monsterdev@broadinstitute.org>"]
 
 packages = [
 	{ include = "dagster_utils" }


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1789)
As part of implementing some small quality-of-life improvements for our HCA snapshot job, I discovered we don't accept blocks for our slack client (for fancier slack notifications), nor does the "noop" Jade client expose the needed `create_snapshot` methods for test mode. 

## This PR
* Adds those methods and updates the slack client with a `blocks` parameter.
