### PR TITLE
Refactoring Beam resources

### DIFF
--- a/dagster_utils/resources/beam/beam_runner.py
+++ b/dagster_utils/resources/beam/beam_runner.py
@@ -1,0 +1,6 @@
+from typing import Any, Protocol
+
+
+class BeamRunner(Protocol):
+    def run(self, run_arg_dict: dict[str, Any], target_class: str, scala_project: str) -> None:
+        ...

--- a/dagster_utils/resources/beam/dataflow_beam_runner.py
+++ b/dagster_utils/resources/beam/dataflow_beam_runner.py
@@ -52,6 +52,7 @@ class DataflowBeamRunner(BeamRunner):
 
 
 @resource({
+    "working_dir": Field(StringSource),
     "region": Field(StringSource),
     "worker_machine_type": Field(StringSource),
     "autoscaling_algorithm": Field(StringSource),

--- a/dagster_utils/resources/beam/dataflow_beam_runner.py
+++ b/dagster_utils/resources/beam/dataflow_beam_runner.py
@@ -1,0 +1,72 @@
+from typing import Any
+from dataclasses import dataclass
+import subprocess
+
+from dagster import DagsterLogManager, resource, Field, IntSource, StringSource
+from dagster.core.execution.context.init import InitResourceContext
+
+from dagster_utils.resources.beam.beam_runner import BeamRunner
+
+
+@dataclass
+class DataflowBeamRunner(BeamRunner):
+    working_dir: str
+    logger: DagsterLogManager
+    region: str
+    worker_machine_type: str
+    autoscaling_algorithm: str
+    num_workers: int
+    max_num_workers: int
+    google_project: str
+
+    def __post_init__(self) -> None:
+        self.arg_dict = {
+            "region": self.region,
+            "workerMachineType": self.worker_machine_type,
+            "autoscalingAlgorithm": self.autoscaling_algorithm,
+            "numWorkers": str(self.num_workers),
+            "maxNumWorkers": str(self.max_num_workers),
+            "project": self.google_project,
+            # specific to dataflow runner
+            "runner": "dataflow",
+            "experiments": "shuffle_mode=service",
+        }
+
+    def run(
+            self,
+            run_arg_dict: dict[str, Any],
+            target_class: str,
+            scala_project: str,
+    ) -> None:
+        # create a new dictionary containing the keys and values of arg_dict + solid arguments
+        dataflow_run_flags = {**self.arg_dict, **run_arg_dict}
+        self.logger.info("Dataflow beam runner")
+
+        # list comprehension over args_dict to get flags
+        flags = " ".join([f'--{arg}={value}' for arg, value in dataflow_run_flags.items()])
+        subprocess.run(
+            ["sbt", f'{scala_project}/runMain {target_class} {flags}'],
+            check=True,
+            cwd=self.working_dir
+        )
+
+
+@resource({
+    "region": Field(StringSource),
+    "worker_machine_type": Field(StringSource),
+    "autoscaling_algorithm": Field(StringSource),
+    "num_workers": Field(IntSource),
+    "max_num_workers": Field(IntSource),
+    "google_project": Field(StringSource),
+})
+def dataflow_beam_runner(init_context: InitResourceContext) -> DataflowBeamRunner:
+    return DataflowBeamRunner(
+        working_dir=init_context.resource_config["working_dir"],
+        region=init_context.resource_config["region"],
+        worker_machine_type=init_context.resource_config["worker_machine_type"],
+        autoscaling_algorithm=init_context.resource_config["autoscaling_algorithm"],
+        num_workers=init_context.resource_config["num_workers"],
+        max_num_workers=init_context.resource_config["max_num_workers"],
+        google_project=init_context.resource_config["google_project"],
+        logger=init_context.log_manager,
+    )

--- a/dagster_utils/resources/beam/k8s_beam_runner.py
+++ b/dagster_utils/resources/beam/k8s_beam_runner.py
@@ -139,7 +139,7 @@ class K8sDataflowBeamRunner(BeamRunner):
     "image_version": Field(StringSource),
     "namespace": Field(StringSource),
 })
-def dataflow_beam_runner(init_context: InitResourceContext) -> K8sDataflowBeamRunner:
+def k8s_dataflow_beam_runner(init_context: InitResourceContext) -> K8sDataflowBeamRunner:
     cloud_config = K8sDataflowCloudConfig(
         project=init_context.resource_config['project'],
         service_account=init_context.resource_config['service_account'],

--- a/dagster_utils/resources/beam/local_beam_runner.py
+++ b/dagster_utils/resources/beam/local_beam_runner.py
@@ -1,0 +1,48 @@
+from typing import Any
+from dataclasses import dataclass
+import subprocess
+
+from dagster import DagsterLogManager, resource, Field, IntSource, StringSource
+from dagster.core.execution.context.init import InitResourceContext
+
+from dagster_utils.resources.beam.beam_runner import BeamRunner
+
+
+@dataclass
+class LocalBeamRunner(BeamRunner):
+    working_dir: str
+    logger: DagsterLogManager
+
+
+    def __post_init__(self) -> None:
+        self.arg_dict = {
+            "runner": "direct",
+        }
+
+    def run(
+            self,
+            run_arg_dict: dict[str, Any],
+            target_class: str,
+            scala_project: str,
+    ) -> None:
+        # create a new dictionary containing the keys and values of arg_dict + solid arguments
+        local_run_flags = {**self.arg_dict, **run_arg_dict}
+        self.logger.info("Local beam runner")
+
+        # list comprehension over args_dict to get flags
+        flags = " ".join([f'--{arg}={value}' for arg, value in local_run_flags.items()])
+        subprocess.run(
+            ["sbt", f'{scala_project}/runMain {target_class} {flags}'],
+            check=True,
+            cwd=self.working_dir
+        )
+
+
+@resource({
+    "working_dir": Field(StringSource),
+})
+def local_beam_runner(init_context: InitResourceContext) -> LocalBeamRunner:
+    return LocalBeamRunner(
+        working_dir=init_context.resource_config["working_dir"],
+        logger=init_context.log_manager
+    )

--- a/dagster_utils/resources/beam/local_beam_runner.py
+++ b/dagster_utils/resources/beam/local_beam_runner.py
@@ -13,7 +13,6 @@ class LocalBeamRunner(BeamRunner):
     working_dir: str
     logger: DagsterLogManager
 
-
     def __post_init__(self) -> None:
         self.arg_dict = {
             "runner": "direct",

--- a/dagster_utils/resources/beam/noop_beam_runner.py
+++ b/dagster_utils/resources/beam/noop_beam_runner.py
@@ -1,0 +1,21 @@
+from typing import Any
+
+from dagster import resource
+from dagster.core.execution.context.init import InitResourceContext
+
+from dagster_utils.resources.beam.beam_runner import BeamRunner
+
+
+class NoopBeamBeamer(BeamRunner):
+    def run(
+            self,
+            run_arg_dict: dict[str, Any],
+            target_class: str,
+            scala_project: str,
+    ) -> None:
+        pass
+
+
+@resource
+def noop_beam_runner(init_context: InitResourceContext) -> NoopBeamBeamer:
+    return NoopBeamBeamer()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "broad_dagster_utils"
 license = "BSD-3-Clause"
 readme = "README.md"
 repository = "https://github.com/broadinstitute/dagster-utils"
-version = "0.4.3"
+version = "0.5.0"
 
 description = "Common utilities and objects for building Dagster pipelines"
 authors = ["Monster Dev <monsterdev@broadinstitute.org>"]


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1781)

## This PR

Refactored resources to create a Beam package with a separate file per runner.
Renamed the DataflowBeamRunner as K8sDataflowBeamRunner for accuracy.
Created a separate DataflowBeamRunner resource as needed for the DAP project.
Created a BeamRunner protocol to standardize the arguments passed in to the run function.
Refactored all of the runners to adhere to the new BeamRunner protocol.
Version bumped to 0.5.0 - note that changes here will break existing projects that use the beam resources package (HCA).

## Library Checklist

- [ ] I have described my changes in detail in my commit message, breaking things down as described in the [README](README.md)
