### PR TITLE
Mark test as ci-only

### DIFF
--- a/.github/workflows/validate-python.yaml
+++ b/.github/workflows/validate-python.yaml
@@ -49,3 +49,6 @@ jobs:
     - name: Run test suite
       run: poetry run pytest
       if: always() && steps.dependencies.outcome == 'success' # run all three checks, even if a prior check fails
+    - name: Run CI-only test suite
+      run: poetry run pytest -m ci_only
+      if: always() && steps.dependencies.outcome == 'success' # run all three checks, even if a prior check fails

--- a/dagster_utils/tests/resources/data_repo/test_jade_data_repo.py
+++ b/dagster_utils/tests/resources/data_repo/test_jade_data_repo.py
@@ -1,11 +1,15 @@
 import unittest
-
+import pytest
 from dagster_utils.resources.data_repo.jade_data_repo import build_client
 
 
 class DataRepoClientTestCase(unittest.TestCase):
 
+    @pytest.mark.ci_only
     def test_client_auths_successfully(self):
+        # make sure we can successfully connect to Jade
+        # this test is marked ci-only as there is some gcloud dependent configuration
+        # needed which may be cumbersome in local dev
         client = build_client(host='https://jade.datarepo-dev.broadinstitute.org/')
         result = client.enumerate_datasets()
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,6 @@
 [pytest]
 console_output_style = progress
+markers = ci_only: marks tests as an ci-only test and not runnable locally without extra configuration
+
+# skip ci_only tests by default
+addopts = -m "not ci_only"


### PR DESCRIPTION
## Why

The Jade data repo connectivity test relies on correctly activated local gcloud dev credentials, which is cumbersome.

## This PR
* Marks the test to only run in our CI environment where we know we have creds setup correctly

## Library Checklist

- [ ] I have described my changes in detail in my commit message, breaking things down as described in the [README](README.md)
