### PR TITLE
Make job name a parameter of BeamRunner::run()

### DIFF
--- a/dagster_utils/resources/beam/beam_runner.py
+++ b/dagster_utils/resources/beam/beam_runner.py
@@ -2,5 +2,5 @@ from typing import Any, Protocol
 
 
 class BeamRunner(Protocol):
-    def run(self, run_arg_dict: dict[str, Any], target_class: str, scala_project: str) -> None:
+    def run(self, run_arg_dict: dict[str, Any], job_name: str, target_class: str, scala_project: str) -> None:
         ...

--- a/dagster_utils/resources/beam/beam_runner.py
+++ b/dagster_utils/resources/beam/beam_runner.py
@@ -1,6 +1,12 @@
-from typing import Any, Protocol
+from typing import Any, Protocol, Optional
 
 
 class BeamRunner(Protocol):
-    def run(self, run_arg_dict: dict[str, Any], job_name: str, target_class: str, scala_project: str) -> None:
+    def run(
+            self,
+            run_arg_dict: dict[str, Any],
+            target_class: str,
+            scala_project: str,
+            job_name: Optional[str] = None
+    ) -> None:
         ...

--- a/dagster_utils/resources/beam/dataflow_beam_runner.py
+++ b/dagster_utils/resources/beam/dataflow_beam_runner.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Optional
 from dataclasses import dataclass
 import subprocess
 
@@ -35,9 +35,9 @@ class DataflowBeamRunner(BeamRunner):
     def run(
             self,
             run_arg_dict: dict[str, Any],
-            job_name: str,
             target_class: str,
             scala_project: str,
+            job_name: Optional[str] = None
     ) -> None:
         # create a new dictionary containing the keys and values of arg_dict + solid arguments
         dataflow_run_flags = {**self.arg_dict, **run_arg_dict}

--- a/dagster_utils/resources/beam/dataflow_beam_runner.py
+++ b/dagster_utils/resources/beam/dataflow_beam_runner.py
@@ -35,6 +35,7 @@ class DataflowBeamRunner(BeamRunner):
     def run(
             self,
             run_arg_dict: dict[str, Any],
+            job_name: str,
             target_class: str,
             scala_project: str,
     ) -> None:

--- a/dagster_utils/resources/beam/k8s_beam_runner.py
+++ b/dagster_utils/resources/beam/k8s_beam_runner.py
@@ -48,11 +48,10 @@ class K8sDataflowBeamRunner(BeamRunner):
     def run(
         self,
         run_arg_dict: dict[str, Any],
+        job_name: str,
         target_class: str,
         scala_project: str
     ) -> None:
-        assert "job_name" in run_arg_dict, "job_name is required for K8s beam runner jobs"
-        job_name = run_arg_dict.pop("job_name")
         args_dict = {
             'runner': 'dataflow',
             'project': self.cloud_config.project,

--- a/dagster_utils/resources/beam/k8s_beam_runner.py
+++ b/dagster_utils/resources/beam/k8s_beam_runner.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import List, Any
+from typing import List, Any, Optional
 from uuid import uuid4
 
 import kubernetes
@@ -48,9 +48,9 @@ class K8sDataflowBeamRunner(BeamRunner):
     def run(
         self,
         run_arg_dict: dict[str, Any],
-        job_name: str,
         target_class: str,
-        scala_project: str
+        scala_project: str,
+        job_name: Optional[str] = None
     ) -> None:
         args_dict = {
             'runner': 'dataflow',
@@ -81,11 +81,15 @@ class K8sDataflowBeamRunner(BeamRunner):
         client = DagsterKubernetesClient.production_client()
         client.wait_for_job_success(job.metadata.name, self.namespace)
 
-    def dispatch_k8s_job(self, image_name: str, job_name_prefix: str, args: List[str]) -> V1Job:
+    def dispatch_k8s_job(self, image_name: str, job_name_prefix: Optional[str], args: List[str]) -> V1Job:
         # we will need to poll the pod/job status on creation
         kubernetes.config.load_kube_config()
 
-        job_name = f"{job_name_prefix}-{uuid4()}"
+        if job_name_prefix:
+            job_name = f"{job_name_prefix}-{uuid4()}"
+        else:
+            job_name = f"{uuid4()}"
+
         pod_name = f"{job_name}-pod"
         job_container = kubernetes.client.V1Container(
             name=job_name,

--- a/dagster_utils/resources/beam/local_beam_runner.py
+++ b/dagster_utils/resources/beam/local_beam_runner.py
@@ -1,8 +1,8 @@
-from typing import Any
-from dataclasses import dataclass
 import subprocess
+from dataclasses import dataclass
+from typing import Any, Optional
 
-from dagster import DagsterLogManager, resource, Field, IntSource, StringSource
+from dagster import DagsterLogManager, resource, Field, StringSource
 from dagster.core.execution.context.init import InitResourceContext
 
 from dagster_utils.resources.beam.beam_runner import BeamRunner
@@ -21,9 +21,9 @@ class LocalBeamRunner(BeamRunner):
     def run(
             self,
             run_arg_dict: dict[str, Any],
-            job_name: str,
             target_class: str,
             scala_project: str,
+            job_name: Optional[str] = None
     ) -> None:
         # create a new dictionary containing the keys and values of arg_dict + solid arguments
         local_run_flags = {**self.arg_dict, **run_arg_dict}

--- a/dagster_utils/resources/beam/local_beam_runner.py
+++ b/dagster_utils/resources/beam/local_beam_runner.py
@@ -21,6 +21,7 @@ class LocalBeamRunner(BeamRunner):
     def run(
             self,
             run_arg_dict: dict[str, Any],
+            job_name: str,
             target_class: str,
             scala_project: str,
     ) -> None:

--- a/dagster_utils/resources/beam/noop_beam_runner.py
+++ b/dagster_utils/resources/beam/noop_beam_runner.py
@@ -10,6 +10,7 @@ class NoopBeamBeamer(BeamRunner):
     def run(
             self,
             run_arg_dict: dict[str, Any],
+            job_name: str,
             target_class: str,
             scala_project: str,
     ) -> None:

--- a/dagster_utils/resources/beam/noop_beam_runner.py
+++ b/dagster_utils/resources/beam/noop_beam_runner.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Optional
 
 from dagster import resource
 from dagster.core.execution.context.init import InitResourceContext
@@ -10,9 +10,9 @@ class NoopBeamBeamer(BeamRunner):
     def run(
             self,
             run_arg_dict: dict[str, Any],
-            job_name: str,
             target_class: str,
             scala_project: str,
+            job_name: Optional[str] = None
     ) -> None:
         pass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ include = [
 # We're locked out of using python 3.10 because the BigQuery library doesn't support it.
 # I'd expect this to change relatively soon after release, so check back occasionally.
 python = "~3.9"
-dagster = "^0.11.6"
+dagster = "^0.11.13"
 google-cloud-storage = "^1.38.0"
 PyYAML = "^5.4.1"
 google-cloud-bigquery = "^2.15.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "broad_dagster_utils"
 license = "BSD-3-Clause"
 readme = "README.md"
 repository = "https://github.com/broadinstitute/dagster-utils"
-version = "0.5.0"
+version = "0.5.1"
 
 description = "Common utilities and objects for building Dagster pipelines"
 authors = ["Monster Dev <monsterdev@broadinstitute.org>"]


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1798)
We need to backport the beam runner changes to HCA. One wrinkle is that the K8S beam runner expects a job name; our initial approach was to pass that through as an arg in the arg dict. However, the local and dataflow beam runner implementations both automatically convert all args in the arg dict to scala direct runner args. Direct runner in turn errors out when it encounters the unexpected jobName variable.

## This PR
* Rather than adding special case code to the local and dataflow beam runners, I've opted to add `job_name` as an optional arg to the BeamRunner protocol's `run` method. 

