### PR TITLE
Force setting of content-type: application/json for SAM to avoid http 415 error

### DIFF
--- a/dagster_utils/resources/sam.py
+++ b/dagster_utils/resources/sam.py
@@ -13,6 +13,8 @@ class Sam:
     base_url: str
 
     def make_snapshot_public(self, snapshot_id: str) -> None:
+        # we are explicitly set content-type in this PUT as the requests lib only sets it when
+        # using the json= kwarg, and SAM will 415 otherwise
         response = self._session().put(
             self._api_url(f'api/resources/v1/datasnapshot/{snapshot_id}/policies/reader/public'),
             headers={"Content-type": "application/json"},

--- a/dagster_utils/resources/sam.py
+++ b/dagster_utils/resources/sam.py
@@ -15,6 +15,7 @@ class Sam:
     def make_snapshot_public(self, snapshot_id: str) -> None:
         response = self._session().put(
             self._api_url(f'api/resources/v1/datasnapshot/{snapshot_id}/policies/reader/public'),
+            headers={"Content-type": "application/json"},
             data="true",  # telling the endpoint to set the flag to true
         )
 

--- a/dagster_utils/tests/resources/test_sam.py
+++ b/dagster_utils/tests/resources/test_sam.py
@@ -9,7 +9,7 @@ from dagster_utils.typing import DagsterConfigDict
 
 class SamResourceTestCase(unittest.TestCase):
     def setUp(self):
-        self.dummy_config: DagsterConfigDict = {'api_url': 'https://zombo.com.fake'}
+        self.dummy_config: DagsterConfigDict = {'api_url': 'https://example.com'}
 
     def test_resource_can_be_initialized_without_extra_config(self):
         with initialize_resource(sam_client, config=self.dummy_config) as client_instance:
@@ -22,5 +22,6 @@ class SamResourceTestCase(unittest.TestCase):
                 client_instance.make_snapshot_public('fake-snapshot-id')
                 mock_authorized_session.put.assert_called_once_with(
                     StringEndingWith('datasnapshot/fake-snapshot-id/policies/reader/public'),
+                    headers={"Content-type": "application/json"},
                     data="true"
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "broad_dagster_utils"
 license = "BSD-3-Clause"
 readme = "README.md"
 repository = "https://github.com/broadinstitute/dagster-utils"
-version = "0.5.1"
+version = "0.5.2"
 
 description = "Common utilities and objects for building Dagster pipelines"
 authors = ["Monster Dev <monsterdev@broadinstitute.org>"]


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1795)
We are getting an HTTP 415 error code when setting snapshots public. I have determined this is due to us not sending an `Content-type: application/json` header in our request.

## This PR
* Explicitly set the needed header in the request (python `requests` will generally do the right thing if you send a `json={...}` payload, but we're sending a raw `data=true` value which short-circuits the automatic setting of the header)
* Bumps the version
