### PR TITLE
Add ability to set a snapshot to private

### DIFF
--- a/dagster_utils/resources/sam.py
+++ b/dagster_utils/resources/sam.py
@@ -12,13 +12,13 @@ from dagster_utils.contrib.google import authorized_session
 class Sam:
     base_url: str
 
-    def make_snapshot_public(self, snapshot_id: str) -> None:
+    def set_public_flag(self, snapshot_id: str, status: bool) -> None:
         # we are explicitly set content-type in this PUT as the requests lib only sets it when
         # using the json= kwarg, and SAM will 415 otherwise
         response = self._session().put(
             self._api_url(f'api/resources/v1/datasnapshot/{snapshot_id}/policies/reader/public'),
             headers={"Content-type": "application/json"},
-            data="true",  # telling the endpoint to set the flag to true
+            data=f"{str(status).lower()}",  # telling the endpoint to set the flag to true/false
         )
 
         # raise an exception for a bad response

--- a/dagster_utils/tests/resources/test_sam.py
+++ b/dagster_utils/tests/resources/test_sam.py
@@ -19,7 +19,7 @@ class SamResourceTestCase(unittest.TestCase):
         with initialize_resource(sam_client, config=self.dummy_config) as client_instance:
             mock_authorized_session = MagicMock()
             with patch('dagster_utils.resources.sam.Sam._session', return_value=mock_authorized_session):
-                client_instance.make_snapshot_public('fake-snapshot-id')
+                client_instance.set_public_flag('fake-snapshot-id', True)
                 mock_authorized_session.put.assert_called_once_with(
                     StringEndingWith('datasnapshot/fake-snapshot-id/policies/reader/public'),
                     headers={"Content-type": "application/json"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "broad_dagster_utils"
 license = "BSD-3-Clause"
 readme = "README.md"
 repository = "https://github.com/broadinstitute/dagster-utils"
-version = "0.6.3"
+version = "0.6.4"
 
 description = "Common utilities and objects for building Dagster pipelines"
 authors = ["Monster Dev <monsterdev@broadinstitute.org>"]


### PR DESCRIPTION
## Why

We need the ability to mark a snapshot private.

## This PR
* Updates the SAM client method to take a bool `status` parameter 

## Checklist

- [ ] Documentation has been updated as needed.
