### PR TITLE
Add job id to error message to speed debugging

### DIFF
--- a/dagster_utils/contrib/data_repo/jobs.py
+++ b/dagster_utils/contrib/data_repo/jobs.py
@@ -41,7 +41,7 @@ def poll_job(
             logging.info(f"Data repo job_id = {job_id} completed")
             if job_info.job_status == "failed":
                 raise JobFailureException(
-                    message="Job did not complete successfully."
+                    message=f"job_id {job_id} did not complete successfully."
                 )
             return job_id
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "broad_dagster_utils"
 license = "BSD-3-Clause"
 readme = "README.md"
 repository = "https://github.com/broadinstitute/dagster-utils"
-version = "0.6.6"
+version = "0.6.7"
 
 description = "Common utilities and objects for building Dagster pipelines"
 authors = ["Monster Dev <monsterdev@broadinstitute.org>"]


### PR DESCRIPTION
## Why

It's difficult to determine which job ID failed when there are many jobs executing in an ingest. We should output the job id as part of the error message.

## This PR
* Adds the job ID to the error message
