### PR TITLE
FE-359 upgrade dagster utils to 3.10 ('3.10', apparently)

### DIFF
--- a/.github/workflows/cut-tag-main.yaml
+++ b/.github/workflows/cut-tag-main.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: 3.10
+        python-version: '3.10'
 
     - name: Install Poetry
       uses: snok/install-poetry@v1

--- a/.github/workflows/publish-tag.yaml
+++ b/.github/workflows/publish-tag.yaml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: 3.10
+        python-version: '3.10'
 
     - name: Install Poetry
       uses: snok/install-poetry@v1


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadworkbench.atlassian.net/browse/FE-359)

## This PR
is a follow on to #36 - the actions couldn't find python 3.1 >> needed to put 3.10 in quotes.

## Checklist

- [x] Documentation has been updated as needed.
