### PR TITLE
FE-375 updating to python 3.10 and Dagster 0.14

### DIFF
--- a/.github/workflows/cut-tag-main.yaml
+++ b/.github/workflows/cut-tag-main.yaml
@@ -14,10 +14,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.10'
 
     - name: Install Poetry
       uses: snok/install-poetry@v1

--- a/.github/workflows/publish-tag.yaml
+++ b/.github/workflows/publish-tag.yaml
@@ -10,10 +10,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.10'
 
     - name: Install Poetry
       uses: snok/install-poetry@v1

--- a/.github/workflows/validate-python.yaml
+++ b/.github/workflows/validate-python.yaml
@@ -16,10 +16,10 @@ jobs:
       PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.10'
 
     - name: 'Set up Cloud SDK'
       uses: 'google-github-actions/setup-gcloud@v1'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "broad_dagster_utils"
 license = "BSD-3-Clause"
 readme = "README.md"
 repository = "https://github.com/broadinstitute/dagster-utils"
-version = "0.7.0-alpha.2"
+version = "2.0.0-alpha.2"
 
 description = "Common utilities and objects for building Dagster pipelines"
 authors = ["Monster Dev <monsterdev@broadinstitute.org>"]
@@ -17,10 +17,8 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-# going back to 3.9 for now - just want to get past the old dagster dependencies & make sure appsec image model works
-python = "~3.9"
-dagster = "^0.13.0"
-# alembic="^1.6.5"
+python = "~3.10"
+dagster = "^0.14.0"
 google-cloud-storage = "^1.38.0"
 PyYAML = "^6.0.2"
 pendulum = "2.1.2"
@@ -28,8 +26,9 @@ google-cloud-bigquery = "^3.27.0"
 slackclient = "^2.9.3"
 argo-workflows = "^5.0.0"
 data-repo-client = "^1.134.0"
-# remove when you upgrade to pyhton 3.12
-setuptools = "^57.5.0"
+# remove when you upgrade to python 3.12
+# this version of setuptools is vulnerable, maybe I don't need to install it anymore?
+# setuptools = "^57.5.0"
 sqlalchemy = "^1.4.54"
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "broad_dagster_utils"
 license = "BSD-3-Clause"
 readme = "README.md"
 repository = "https://github.com/broadinstitute/dagster-utils"
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.3"
 
 description = "Common utilities and objects for building Dagster pipelines"
 authors = ["Monster Dev <monsterdev@broadinstitute.org>"]


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadworkbench.atlassian.net/browse/FE-375)

## This PR

**Breaking changes**

- updates Python to 3.10
- updates Dagster to 0.14

**Known Issues**

Cut tag & Publish tag actions are broken, we need to set up GSM - this does not impact the use of dagster-utils, but it does require manual tag, release & publish to PyPi

## Checklist

- [x] Documentation has been updated as needed.
