### PR TITLE
Update package version to 2.0.0a6, and update Dagster to 0.15

### DIFF
--- a/dagster_utils/resources/slack.py
+++ b/dagster_utils/resources/slack.py
@@ -9,7 +9,7 @@ from dagster.core.execution.context.init import InitResourceContext
 #
 # from dagster_utils.typing import DagsterHookFunction
 
-SlackMessageGenerator = Callable[[HookContext], str]
+SlackMessageGenerator = Callable[[dg.HookContext], str]
 
 
 @dataclass

--- a/dagster_utils/resources/slack.py
+++ b/dagster_utils/resources/slack.py
@@ -1,45 +1,46 @@
 from dataclasses import dataclass
 from typing import Callable, Literal, Optional
 
-import slack
-from dagster import DagsterLogManager, failure_hook, HookContext, HookDefinition,\
-    resource, String, StringSource, success_hook
+from slack_sdk import WebClient
+import dagster as dg
 from dagster.core.execution.context.init import InitResourceContext
-
-from dagster_utils.typing import DagsterHookFunction
+# from dagster import DagsterLogManager, failure_hook, HookContext, HookDefinition,\
+#     resource, String, StringSource, success_hook
+#
+# from dagster_utils.typing import DagsterHookFunction
 
 SlackMessageGenerator = Callable[[HookContext], str]
 
 
 @dataclass
 class ConsoleSlackClient:
-    logger: DagsterLogManager
+    logger: dg.DagsterLogManager
 
     def send_message(self, text: Optional[str] = None, blocks: Optional[list[dict[str, object]]] = None) -> None:
         self.logger.info(f"[SLACK] {text} {blocks}")
 
 
-@resource
+@dg.resource
 def console_slack_client(init_context: InitResourceContext) -> ConsoleSlackClient:
     return ConsoleSlackClient(init_context.log)
 
 
 @dataclass
 class LiveSlackClient:
-    client: slack.WebClient
+    client: WebClient
     channel: str
 
     def send_message(self, text: Optional[str] = None, blocks: Optional[list[dict[str, object]]] = None) -> None:
         self.client.chat_postMessage(channel=self.channel, text=text, blocks=blocks)
 
 
-@resource({
-    'channel': String,
-    'token': StringSource,
+@dg.resource({
+    'channel': dg.String,
+    'token': dg.StringSource,
 })
 def live_slack_client(init_context: InitResourceContext) -> LiveSlackClient:
     return LiveSlackClient(
-        slack.WebClient(init_context.resource_config['token']),
+        WebClient(init_context.resource_config['token']),
         init_context.resource_config['channel'],
     )
 
@@ -47,10 +48,10 @@ def live_slack_client(init_context: InitResourceContext) -> LiveSlackClient:
 def slack_hook(
     on: Literal['success', 'failure'],
     additional_resource_keys: set[str] = set()
-) -> Callable[[SlackMessageGenerator], DagsterHookFunction]:
+) -> Callable[[SlackMessageGenerator], dg.HookDefinition]:
     """
     Decorator function for Slack hooks - decorate a function that generates a message to turn it
-    into a boilerplate Slack hook you can bind to solids/pipelines. Presumes that the Slack resource
+    into a boilerplate Slack hook you can bind to ops/jobs. Presumes that the Slack resource
     is already fully configured with its target channel and token.
 
     Example usage (real world example):
@@ -66,14 +67,14 @@ def slack_hook(
     """
 
     if on == 'success':
-        hook_decorator = success_hook
+        hook_decorator = dg.success_hook
     elif on == 'failure':
-        hook_decorator = failure_hook
+        hook_decorator = dg.failure_hook
 
-    def message_generation_wrapper(message_generator: SlackMessageGenerator) -> HookDefinition:
+    def message_generation_wrapper(message_generator: SlackMessageGenerator) -> dg.HookDefinition:
 
         @hook_decorator(required_resource_keys=({'slack'} | additional_resource_keys))
-        def _send_slack_message(context: HookContext) -> None:
+        def _send_slack_message(context: dg.HookContext) -> None:
             context.resources.slack.send_message(message_generator(context))
 
         return _send_slack_message

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "broad_dagster_utils"
 license = "BSD-3-Clause"
 readme = "README.md"
 repository = "https://github.com/broadinstitute/dagster-utils"
-version = "2.0.0-alpha.5"
+version = "2.0.0-alpha.6"
 
 description = "Common utilities and objects for building Dagster pipelines"
 authors = ["Monster Dev <monsterdev@broadinstitute.org>"]
@@ -23,10 +23,11 @@ google-cloud-storage = "^1.38.0"
 PyYAML = "^6.0.2"
 pendulum = "2.1.2"
 google-cloud-bigquery = "<3"
-slackclient = "^2.9.3"
+slack_sdk = "^3.18.0"
 argo-workflows = "^5.0.0"
 data-repo-client = "^1.134.0"
 sqlalchemy = "^1.4.54"
+distlib = "0.3.9"
 
 [tool.poetry.group.dev.dependencies]
 autopep8 = "^1.5.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "broad_dagster_utils"
 license = "BSD-3-Clause"
 readme = "README.md"
 repository = "https://github.com/broadinstitute/dagster-utils"
-version = "2.0.0-alpha.4"
+version = "2.0.0-alpha.5"
 
 description = "Common utilities and objects for building Dagster pipelines"
 authors = ["Monster Dev <monsterdev@broadinstitute.org>"]
@@ -18,7 +18,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "~3.10"
-dagster = "^0.14.0"
+dagster = "^0.15.0"
 google-cloud-storage = "^1.38.0"
 PyYAML = "^6.0.2"
 pendulum = "2.1.2"
@@ -26,9 +26,6 @@ google-cloud-bigquery = "<3"
 slackclient = "^2.9.3"
 argo-workflows = "^5.0.0"
 data-repo-client = "^1.134.0"
-# remove when you upgrade to python 3.12
-# this version of setuptools is vulnerable, maybe I don't need to install it anymore?
-# setuptools = "^57.5.0"
 sqlalchemy = "^1.4.54"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadworkbench.atlassian.net/browse/FE-374)

## This PR
**Breaking Changes**
- updates [Dagster to 0.15](https://github.com/dagster-io/dagster/blob/master/MIGRATION.md#migrating-to-0150)

**Known Issues**
Cut tag & Publish tag actions are broken, we need to set up GSM - this does not impact the use of dagster-utils, but it does require manual tag, release & publish to PyPi

This work is in support of upgrading the hca ingest workflow to Dagster 0.15 [FE-380](https://broadworkbench.atlassian.net/browse/FE-380)

## Checklist

- [x]Documentation has been updated as needed.


[FE-380]: https://broadworkbench.atlassian.net/browse/FE-380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ