### PR TITLE
FE-377 update broad dagster utils pkg to dagster 1.0.0

### DIFF
--- a/dagster_utils/typing.py
+++ b/dagster_utils/typing.py
@@ -5,7 +5,7 @@ Types and type annotations useful for Dagster applications.
 from dagster import HookContext
 from dagster.config import ConfigType as DagsterConfigType
 
-from typing import Callable, Literal, Protocol, TypedDict, Union
+from typing import Callable, Literal, Protocol, Union
 
 
 # dict of config settings for a given instance of a dagster object

--- a/dagster_utils/typing.py
+++ b/dagster_utils/typing.py
@@ -2,7 +2,7 @@
 Types and type annotations useful for Dagster applications.
 """
 
-from dagster import HookContext, InputDefinition
+from dagster import HookContext
 from dagster.config import ConfigType as DagsterConfigType
 
 from typing import Callable, Literal, Protocol, TypedDict, Union
@@ -24,17 +24,19 @@ DagsterConfigDict = dict[
     ]
 ]
 
-# dict representing how a solid can be configured
+# dict representing how an op can be configured
 DagsterObjectConfigSchema = dict[str, DagsterConfigType]
 
 DagsterHookFunction = Callable[[HookContext], None]
 
 
-# a partial delineation of the config for a Dagster solid.
-class DagsterSolidConfig(TypedDict, total=False):
-    required_resource_keys: set[str]
-    input_defs: list[InputDefinition]
-    config_schema: DagsterObjectConfigSchema
+# TODO clean this up and remove the commented out code
+#  - this class is not used in dagster-utils or in hca-ingest
+# a partial delineation of the config for a Dagster op.
+# class DagsterOpConfig(TypedDict, total=False):
+#     required_resource_keys: set[str]
+#     input_defs: list[In]
+#     config_schema: DagsterObjectConfigSchema
 
 
 # a package whose location on the filesystem is fetchable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ include = [
 
 [tool.poetry.dependencies]
 python = "~3.10"
-dagster = "^1.0.17"
-google-cloud-storage = "^1.38.0"
+dagster = "1.0.17"
+google-cloud-storage = "^2.6.0"
 PyYAML = "^6.0.2"
 pendulum = "2.1.2"
 google-cloud-bigquery = "<3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "~3.10"
-dagster = "^1.0.0"
+dagster = "^1.0.17"
 google-cloud-storage = "^1.38.0"
 PyYAML = "^6.0.2"
 pendulum = "2.1.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "~3.10"
-dagster = "^0.15.0"
+dagster = "^1.0.0"
 google-cloud-storage = "^1.38.0"
 PyYAML = "^6.0.2"
 pendulum = "2.1.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "broad_dagster_utils"
 license = "BSD-3-Clause"
 readme = "README.md"
 repository = "https://github.com/broadinstitute/dagster-utils"
-version = "2.0.0-alpha.6"
+version = "2.0.0-alpha.7"
 
 description = "Common utilities and objects for building Dagster pipelines"
 authors = ["Monster Dev <monsterdev@broadinstitute.org>"]


### PR DESCRIPTION
## Why

[FE-377](https://broadworkbench.atlassian.net/browse/FE-377)


## This PR

**Breaking Changes**

- updates [Dagster to 1.0.0](https://github.com/dagster-io/dagster/blob/master/MIGRATION.md#migrating-to-10)

**Known Issues**
Cut tag & Publish tag actions are broken, we need to set up GSM - this does not impact the use of dagster-utils, but it does require manual tag, release & publish to PyPi

This work is in support of upgrading the hca ingest workflow to Dagster 1.0.0 [FE-390](https://broadworkbench.atlassian.net/browse/FE-390)


## Checklist

- [x] Documentation has been updated as needed.


[FE-377]: https://broadworkbench.atlassian.net/browse/FE-377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FE-390]: https://broadworkbench.atlassian.net/browse/FE-390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ